### PR TITLE
Set install path of slint tools to `usr/local/bin`

### DIFF
--- a/image/Containerfile
+++ b/image/Containerfile
@@ -9,10 +9,6 @@ LABEL com.github.containers.toolbox="true" \
       usage="This image is meant to be used with the toolbox(1) command" \
       summary="Image for creating Fedora Toolbx containers"
 
-# Add copr repositories
-RUN dnf --assumeyes copr enable petersen/haskell-language-server
-RUN dnf --assumeyes copr enable yorickpeterse/lua-language-server
-
 # Install extra packages
 COPY extra-packages /
 RUN dnf --assumeyes install $(<extra-packages)

--- a/image/extra-packages
+++ b/image/extra-packages
@@ -5,8 +5,6 @@ fd-find
 gcc
 gcc-c++
 gh
-haskell-language-server
-lua-language-server
 neovim
 nodejs-bash-language-server
 openssl-devel

--- a/image/slint-tools
+++ b/image/slint-tools
@@ -7,7 +7,7 @@ install() {
     wget "$GITHUB_URL/$TOOL-linux.tar.gz"
     tar xvzf "$TOOL-linux.tar.gz" "$TOOL/$TOOL"
     rm "$TOOL-linux.tar.gz"
-    mv "$TOOL/$TOOL" "/usr/bin"
+    mv "$TOOL/$TOOL" "/usr/local/bin"
     rmdir "$TOOL"
 }
 


### PR DESCRIPTION
**Changes**
- Set install path of slint tools to `usr/local/bin`
- Removes software that relies on copr, i.e. `haskell-language-server` and `lua-language-server`