### PR TITLE
Enable X11 support in sandbox for java gui applications

### DIFF
--- a/image/extra-packages
+++ b/image/extra-packages
@@ -6,6 +6,7 @@ fd-find
 gcc
 gcc-c++
 haskell-language-server
+java-latest-openjdk
 lua-language-server
 neovim
 nodejs-bash-language-server

--- a/image/sandbox
+++ b/image/sandbox
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 WAYLAND="$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY"
+X11_UNIX="/tmp/.X11-unix"
 
 HOME_DIR="$HOME/.var/box"
 mkdir --parents "$HOME_DIR"
@@ -33,6 +34,8 @@ bwrap \
     --ro-bind /usr /usr \
     --ro-bind /sys /sys \
     --ro-bind "$WAYLAND" "$WAYLAND" \
+    --ro-bind "$X11_UNIX" "$X11_UNIX" \
+    --ro-bind "$XAUTHORITY" "$XAUTHORITY" \
     --ro-bind "/run/.containerenv" "/run/.containerenv" \
     --ro-bind "/run/.toolboxenv" "/run/.toolboxenv" \
     --ro-bind "/run/systemd/resolve" "/run/systemd/resolve" \


### PR DESCRIPTION
**Changes**
- Add `java-latest-openjdk` package
- Add X11 support to sandbox